### PR TITLE
Don't ignore too long lines in nss_files (Upstream BZ #17079)

### DIFF
--- a/src/nss_altfiles/files-XXX.c
+++ b/src/nss_altfiles/files-XXX.c
@@ -196,9 +196,11 @@ get_contents (char *linebuf, size_t len, FILE *stream)
     {
       int curlen = ((remaining_len > (size_t) INT_MAX) ? INT_MAX
 		    : remaining_len);
-      char *p = fgets_unlocked (curbuf, curlen, stream);
 
+      /* Terminate the line so that we can test for overflow.  */
       ((unsigned char *) curbuf)[curlen - 1] = 0xff;
+
+      char *p = fgets_unlocked (curbuf, curlen, stream);
 
       /* EOF or read error.  */
       if (p == NULL)


### PR DESCRIPTION
Fix from upstream glibc commit
ac60763eac3d43b7234dd21286ad3ec3f17957fc by Andreas Schwab.

This fixes CVE-2015-5277.

See https://sourceware.org/bugzilla/show_bug.cgi?id=17079